### PR TITLE
update ibc-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datachainlab/ibc-proxy
 go 1.16
 
 replace (
-	github.com/cosmos/ibc-go => github.com/datachainlab/ibc-go v0.0.0-20210614083531-e8e25aabc360
+	github.com/cosmos/ibc-go => github.com/datachainlab/ibc-go v0.0.0-20210623043207-6582d8c965f8
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
-github.com/datachainlab/ibc-go v0.0.0-20210614083531-e8e25aabc360 h1:vwo5KVzMUlBo7hQrwZVIFMXAWJfR8pSqimRTtH1fGM4=
-github.com/datachainlab/ibc-go v0.0.0-20210614083531-e8e25aabc360/go.mod h1:NU4IARjXt3Hj5xcju207SWjDMpqMx3CHUXejGe0EXfY=
+github.com/datachainlab/ibc-go v0.0.0-20210623043207-6582d8c965f8 h1:Nx9l9NCCKvCmGDDQslhKHc4hWXINcMKFykMQjrvu5o8=
+github.com/datachainlab/ibc-go v0.0.0-20210623043207-6582d8c965f8/go.mod h1:NU4IARjXt3Hj5xcju207SWjDMpqMx3CHUXejGe0EXfY=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/modules/light-clients/xx-multiv/types/client_state.go
+++ b/modules/light-clients/xx-multiv/types/client_state.go
@@ -356,20 +356,20 @@ func (cs *ClientState) VerifyChannelState(store sdk.KVStore, cdc codec.BinaryCod
 	return cs.GetBaseClientState().VerifyChannelState(store, cdc, height, prefix, proof, portID, channelID, channel)
 }
 
-func (cs *ClientState) VerifyPacketCommitment(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, commitmentBytes []byte) error {
-	return cs.GetBaseClientState().VerifyPacketCommitment(store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence, commitmentBytes)
+func (cs *ClientState) VerifyPacketCommitment(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, commitmentBytes []byte) error {
+	return cs.GetBaseClientState().VerifyPacketCommitment(ctx, store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence, commitmentBytes)
 }
 
-func (cs *ClientState) VerifyPacketAcknowledgement(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, acknowledgement []byte) error {
-	return cs.GetBaseClientState().VerifyPacketAcknowledgement(store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence, acknowledgement)
+func (cs *ClientState) VerifyPacketAcknowledgement(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, acknowledgement []byte) error {
+	return cs.GetBaseClientState().VerifyPacketAcknowledgement(ctx, store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence, acknowledgement)
 }
 
-func (cs *ClientState) VerifyPacketReceiptAbsence(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64) error {
-	return cs.GetBaseClientState().VerifyPacketReceiptAbsence(store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence)
+func (cs *ClientState) VerifyPacketReceiptAbsence(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64) error {
+	return cs.GetBaseClientState().VerifyPacketReceiptAbsence(ctx, store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, sequence)
 }
 
-func (cs *ClientState) VerifyNextSequenceRecv(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, nextSequenceRecv uint64) error {
-	return cs.GetBaseClientState().VerifyNextSequenceRecv(store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, nextSequenceRecv)
+func (cs *ClientState) VerifyNextSequenceRecv(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, nextSequenceRecv uint64) error {
+	return cs.GetBaseClientState().VerifyNextSequenceRecv(ctx, store, cdc, height, currentTimestamp, delayPeriod, prefix, proof, portID, channelID, nextSequenceRecv)
 }
 
 func unpackProxyClientState(cdc codec.BinaryCodec, anyClientState *types.Any) (*proxytypes.ClientState, error) {

--- a/modules/light-clients/xx-multiv/types/update.go
+++ b/modules/light-clients/xx-multiv/types/update.go
@@ -34,8 +34,8 @@ func (cs *ClientState) CheckMisbehaviourAndUpdateState(ctx sdk.Context, cdc code
 	return cs, nil
 }
 
-func (cs *ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore sdk.KVStore, substituteClientStore sdk.KVStore, substituteClient exported.ClientState, height exported.Height) (exported.ClientState, error) {
-	clientState, err := cs.GetBaseClientState().CheckSubstituteAndUpdateState(ctx, cdc, subjectClientStore, substituteClientStore, substituteClient, height)
+func (cs *ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore sdk.KVStore, substituteClientStore sdk.KVStore, substituteClient exported.ClientState) (exported.ClientState, error) {
+	clientState, err := cs.GetBaseClientState().CheckSubstituteAndUpdateState(ctx, cdc, subjectClientStore, substituteClientStore, substituteClient)
 	anyClientState, err := clienttypes.PackClientState(clientState)
 	if err != nil {
 		return nil, err

--- a/modules/light-clients/xx-proxy/types/client_state.go
+++ b/modules/light-clients/xx-proxy/types/client_state.go
@@ -130,20 +130,20 @@ func (cs *ClientState) VerifyChannelState(store sdk.KVStore, cdc codec.BinaryCod
 	return cs.GetProxyClientState().VerifyChannelState(NewProxyStore(cdc, store), cdc, height, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, channel)
 }
 
-func (cs *ClientState) VerifyPacketCommitment(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, commitmentBytes []byte) error {
-	return cs.GetProxyClientState().VerifyPacketCommitment(NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence, commitmentBytes)
+func (cs *ClientState) VerifyPacketCommitment(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, commitmentBytes []byte) error {
+	return cs.GetProxyClientState().VerifyPacketCommitment(ctx, NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence, commitmentBytes)
 }
 
-func (cs *ClientState) VerifyPacketAcknowledgement(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, acknowledgement []byte) error {
-	return cs.GetProxyClientState().VerifyPacketAcknowledgement(NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence, acknowledgement)
+func (cs *ClientState) VerifyPacketAcknowledgement(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64, acknowledgement []byte) error {
+	return cs.GetProxyClientState().VerifyPacketAcknowledgement(ctx, NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence, acknowledgement)
 }
 
-func (cs *ClientState) VerifyPacketReceiptAbsence(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64) error {
-	return cs.GetProxyClientState().VerifyPacketReceiptAbsence(NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence)
+func (cs *ClientState) VerifyPacketReceiptAbsence(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, sequence uint64) error {
+	return cs.GetProxyClientState().VerifyPacketReceiptAbsence(ctx, NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, sequence)
 }
 
-func (cs *ClientState) VerifyNextSequenceRecv(store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, nextSequenceRecv uint64) error {
-	return cs.GetProxyClientState().VerifyNextSequenceRecv(NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, nextSequenceRecv)
+func (cs *ClientState) VerifyNextSequenceRecv(ctx sdk.Context, store sdk.KVStore, cdc codec.BinaryCodec, height exported.Height, currentTimestamp uint64, delayPeriod uint64, prefix exported.Prefix, proof []byte, portID string, channelID string, nextSequenceRecv uint64) error {
+	return cs.GetProxyClientState().VerifyNextSequenceRecv(ctx, NewProxyStore(cdc, store), cdc, height, currentTimestamp, delayPeriod, newPrefix(cs.ProxyPrefix, prefix, cs.UpstreamClientId), proof, portID, channelID, nextSequenceRecv)
 }
 
 func newPrefix(proxyPrefix, upstreamPrefix exported.Prefix, upstreamClientID string) exported.Prefix {

--- a/modules/light-clients/xx-proxy/types/update.go
+++ b/modules/light-clients/xx-proxy/types/update.go
@@ -42,8 +42,8 @@ func (cs *ClientState) CheckMisbehaviourAndUpdateState(ctx sdk.Context, cdc code
 	return cs, nil
 }
 
-func (cs *ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore sdk.KVStore, substituteClientStore sdk.KVStore, substituteClient exported.ClientState, height exported.Height) (exported.ClientState, error) {
-	clientState, err := cs.GetProxyClientState().CheckSubstituteAndUpdateState(ctx, cdc, subjectClientStore, substituteClientStore, substituteClient, height)
+func (cs *ClientState) CheckSubstituteAndUpdateState(ctx sdk.Context, cdc codec.BinaryCodec, subjectClientStore sdk.KVStore, substituteClientStore sdk.KVStore, substituteClient exported.ClientState) (exported.ClientState, error) {
+	clientState, err := cs.GetProxyClientState().CheckSubstituteAndUpdateState(ctx, cdc, subjectClientStore, substituteClientStore, substituteClient)
 	anyClientState, err := clienttypes.PackClientState(clientState)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func NewProxyStore(cdc codec.BinaryCodec, store sdk.KVStore) ProxyStore {
 
 func (s ProxyStore) Get(key []byte) []byte {
 	k := string(key)
-	if !strings.HasPrefix(k, host.KeyConsensusStatePrefix+"/") || strings.HasSuffix(k, "/processedTime") {
+	if !strings.HasPrefix(k, host.KeyConsensusStatePrefix+"/") || strings.HasSuffix(k, "/processedTime") || strings.HasSuffix(k, "/processedHeight") {
 		return s.KVStore.Get(key)
 	}
 	v := s.KVStore.Get(key)

--- a/modules/proxy/module.go
+++ b/modules/proxy/module.go
@@ -197,11 +197,11 @@ func (am AppModule) OnChanCloseConfirm(ctx sdk.Context, portID string, channelID
 // If the acknowledgement returned is successful, the state changes on callback are written,
 // otherwise the application state changes are discarded. In either case the packet is received
 // and the acknowledgement is written (in synchronous cases).
-func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet) exported.Acknowledgement {
+func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) exported.Acknowledgement {
 	return am.keeper.OnRecvPacket(ctx, packet)
 }
 
-func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte) (*sdk.Result, error) {
+func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte, relayer sdk.AccAddress) (*sdk.Result, error) {
 	var ack channeltypes.Acknowledgement
 	if err := types.ModuleCdc.UnmarshalJSON(acknowledgement, &ack); err != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-20 transfer packet acknowledgement: %v", err)
@@ -216,6 +216,6 @@ func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes
 	}, nil
 }
 
-func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet) (*sdk.Result, error) {
+func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) (*sdk.Result, error) {
 	panic("not implemented") // TODO: Implement
 }

--- a/modules/proxy/types/expected_keepers.go
+++ b/modules/proxy/types/expected_keepers.go
@@ -21,6 +21,7 @@ type ClientKeeper interface {
 // ConnectionKeeper defines the expected IBC connection keeper
 type ConnectionKeeper interface {
 	GetConnection(ctx sdk.Context, connectionID string) (connection connectiontypes.ConnectionEnd, found bool)
+	GetMaxExpectedTimePerBlock(ctx sdk.Context) uint64
 }
 
 // ChannelKeeper defines the expected IBC channel keeper

--- a/testing/mock/mock.go
+++ b/testing/mock/mock.go
@@ -17,6 +17,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	channeltypes "github.com/cosmos/ibc-go/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/modules/core/05-port/types"
 	host "github.com/cosmos/ibc-go/modules/core/24-host"
 	"github.com/cosmos/ibc-go/modules/core/exported"
 )
@@ -33,6 +34,8 @@ var (
 	MockAsyncPacketData      = []byte("mock async packet data")
 	MockCanaryCapabilityName = "mock canary capability name"
 )
+
+var _ porttypes.IBCModule = AppModule{}
 
 // Expected Interface
 // PortKeeper defines the expected IBC port keeper
@@ -189,7 +192,7 @@ func (am AppModule) OnChanCloseConfirm(sdk.Context, string, string) error {
 }
 
 // OnRecvPacket implements the IBCModule interface.
-func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet) exported.Acknowledgement {
+func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) exported.Acknowledgement {
 	// set state by claiming capability to check if revert happens return
 	am.scopedKeeper.NewCapability(ctx, MockCanaryCapabilityName)
 	if bytes.Equal(MockPacketData, packet.GetData()) {
@@ -202,11 +205,11 @@ func (am AppModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet) ex
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface.
-func (am AppModule) OnAcknowledgementPacket(sdk.Context, channeltypes.Packet, []byte) (*sdk.Result, error) {
+func (am AppModule) OnAcknowledgementPacket(sdk.Context, channeltypes.Packet, []byte, sdk.AccAddress) (*sdk.Result, error) {
 	return nil, nil
 }
 
 // OnTimeoutPacket implements the IBCModule interface.
-func (am AppModule) OnTimeoutPacket(sdk.Context, channeltypes.Packet) (*sdk.Result, error) {
+func (am AppModule) OnTimeoutPacket(sdk.Context, channeltypes.Packet, sdk.AccAddress) (*sdk.Result, error) {
 	return nil, nil
 }

--- a/testing/mock/privval_test.go
+++ b/testing/mock/privval_test.go
@@ -7,7 +7,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/datachainlab/ibc-proxy/testing/mock"
+	"github.com/cosmos/ibc-go/testing/mock"
 )
 
 const chainID = "testChain"

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/capability"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
@@ -306,7 +307,7 @@ func NewSimApp(
 	ibcKeeper := ibckeeper.NewKeeper(
 		appCodec, keys[ibchost.StoreKey], app.GetSubspace(ibchost.ModuleName), app.StakingKeeper, app.UpgradeKeeper, scopedIBCKeeper,
 	)
-	app.IBCKeeper = applyPatchToIBCKeeper(*ibcKeeper, appCodec, keys[ibchost.StoreKey])
+	app.IBCKeeper = applyPatchToIBCKeeper(*ibcKeeper, appCodec, keys[ibchost.StoreKey], app.GetSubspace(ibchost.ModuleName))
 
 	app.IBCProxyKeeper = ibcproxykeeper.NewKeeper(
 		appCodec, keys[ibcproxytypes.StoreKey], keys[ibchost.StoreKey], app.IBCKeeper.ClientKeeper, app.IBCKeeper.ConnectionKeeper, app.IBCKeeper.ChannelKeeper, scopedIBCProxyKeeper, &app.IBCKeeper.PortKeeper,
@@ -491,9 +492,9 @@ func NewSimApp(
 	return app
 }
 
-func applyPatchToIBCKeeper(k ibckeeper.Keeper, cdc codec.BinaryCodec, key sdk.StoreKey) *ibckeeper.Keeper {
+func applyPatchToIBCKeeper(k ibckeeper.Keeper, cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace) *ibckeeper.Keeper {
 	clientKeeper := ibcproxykeeper.NewClientKeeper(k.ClientKeeper)
-	k.ConnectionKeeper = ibcconnectionkeeper.NewKeeper(cdc, key, clientKeeper)
+	k.ConnectionKeeper = ibcconnectionkeeper.NewKeeper(cdc, key, paramSpace, clientKeeper)
 	return &k
 }
 


### PR DESCRIPTION
Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>

Update ibc-go version to a fork of [v1.0.0-beta1](https://github.com/cosmos/ibc-go/releases/tag/v1.0.0-beta1)